### PR TITLE
Namespace FIX: + USE_SCOPED_HEADER_INSTALL_DIR FIX

### DIFF
--- a/play_motion2/CMakeLists.txt
+++ b/play_motion2/CMakeLists.txt
@@ -102,4 +102,4 @@ if(BUILD_TESTING)
   endforeach()
 endif()
 
-ament_auto_package(INSTALL_TO_SHARE config launch)
+ament_auto_package(INSTALL_TO_SHARE config launch USE_SCOPED_HEADER_INSTALL_DIR)

--- a/play_motion2/config/motion_planner_config.yaml
+++ b/play_motion2/config/motion_planner_config.yaml
@@ -1,6 +1,9 @@
 play_motion2_executor:
   ros__parameters:
     motion_planner:
+      disable_motion_planning: true
+      planning_groups: # Sorted by order of preference
+        - planning_group_1
       approach_velocity: 0.5
       approach_min_duration: 0.5
 

--- a/play_motion2/config/motions.yaml
+++ b/play_motion2/config/motions.yaml
@@ -1,0 +1,12 @@
+play_motion2_mgr:
+  ros__parameters:
+    motions:
+      motion_1:
+        joints: [joint1, joint2]
+        positions: [0.0, 0.0,
+                    0.5, 0.25]
+        times_from_start: [0.5, 1.0]
+        meta:
+          name: Motion_1
+          usage: example
+          description: 'Example Motion'

--- a/play_motion2/launch/play_motion2.launch.py
+++ b/play_motion2/launch/play_motion2.launch.py
@@ -30,6 +30,8 @@ def generate_launch_description():
 
     motions_config = DeclareLaunchArgument(
         'motions_file',
+        default_value=os.path.join(
+            get_package_share_directory('play_motion2'), 'config', 'motions.yaml'),
         description='Yaml file with the info of the motions. ')
 
     motion_planner_config = DeclareLaunchArgument(

--- a/play_motion2/src/play_motion2/client.cpp
+++ b/play_motion2/src/play_motion2/client.cpp
@@ -33,16 +33,16 @@ PlayMotion2Client::PlayMotion2Client(const std::string & name, const rclcpp::Nod
   , running_motion_(false)
   , motion_succeeded_(false)
 {
-  play_motion2_client_ = rclcpp_action::create_client<PlayMotion2>(this, "/play_motion2");
+  play_motion2_client_ = rclcpp_action::create_client<PlayMotion2>(this, "play_motion2");
   play_motion2_client_raw_ =
-    rclcpp_action::create_client<PlayMotion2Raw>(this, "/play_motion2/raw");
+    rclcpp_action::create_client<PlayMotion2Raw>(this, "play_motion2/raw");
 
-  get_motion_info_client_ = this->create_client<GetMotionInfo>("/play_motion2/get_motion_info");
-  is_motion_ready_client_ = this->create_client<IsMotionReady>("/play_motion2/is_motion_ready");
-  list_motions_client_ = this->create_client<ListMotions>("/play_motion2/list_motions");
+  get_motion_info_client_ = this->create_client<GetMotionInfo>("play_motion2/get_motion_info");
+  is_motion_ready_client_ = this->create_client<IsMotionReady>("play_motion2/is_motion_ready");
+  list_motions_client_ = this->create_client<ListMotions>("play_motion2/list_motions");
 
-  add_motion_client_ = this->create_client<AddMotion>("/play_motion2/add_motion");
-  remove_motion_client_ = this->create_client<RemoveMotion>("/play_motion2/remove_motion");
+  add_motion_client_ = this->create_client<AddMotion>("play_motion2/add_motion");
+  remove_motion_client_ = this->create_client<RemoveMotion>("play_motion2/remove_motion");
 }
 
 PlayMotion2Client::~PlayMotion2Client()

--- a/play_motion2/src/utils/motion_planner.cpp
+++ b/play_motion2/src/utils/motion_planner.cpp
@@ -77,13 +77,13 @@ MotionPlanner::MotionPlanner(rclcpp_lifecycle::LifecycleNode::SharedPtr node)
 
   joint_states_sub_ =
     node_->create_subscription<JointState>(
-    "/joint_states", 1,
+    "joint_states", 1,
     std::bind(&MotionPlanner::joint_states_callback, this, _1), options);
 
   list_controllers_client_ = node_->create_client<ListControllers>(
-    "/controller_manager/list_controllers", rmw_qos_profile_default, motion_planner_cb_group_);
+    "controller_manager/list_controllers", rmw_qos_profile_default, motion_planner_cb_group_);
 
-  move_group_node_ = rclcpp::Node::make_shared("_move_group_node", node_->get_name());
+    move_group_node_ = std::make_shared<rclcpp::Node>("_move_group_node", node_->get_namespace());
 
   check_parameters();
 }
@@ -180,11 +180,14 @@ void MotionPlanner::check_parameters()
       }
     };
 
-  wait_for_description("/robot_description");
-  wait_for_description("/robot_description_semantic");
+  wait_for_description("robot_description");
+  wait_for_description("robot_description_semantic");
 
   for (const auto & group : planning_groups_) {
-    move_groups_.emplace_back(std::make_shared<MoveGroupInterface>(move_group_node_, group));
+    moveit::planning_interface::MoveGroupInterface::Options opt(group, "robot_description", node_->get_namespace());
+    auto mgi = std::make_shared<moveit::planning_interface::MoveGroupInterface>(move_group_node_, opt);
+    move_groups_.emplace_back(std::move(mgi));
+    RCLCPP_INFO(node_->get_logger(), "MoveGroupInterface created for group: %s", group.c_str());
   }
 }
 
@@ -641,7 +644,7 @@ FollowJTGoalHandleFutureResult MotionPlanner::send_trajectory(
   } else {
     action_client = rclcpp_action::create_client<FollowJointTrajectory>(
       node_,
-      "/" + controller_name + "/follow_joint_trajectory",
+      controller_name + "/follow_joint_trajectory",
       motion_planner_cb_group_);
     action_clients_[controller_name] = action_client;
   }
@@ -649,7 +652,7 @@ FollowJTGoalHandleFutureResult MotionPlanner::send_trajectory(
   if (!action_client->wait_for_action_server(1s)) {
     RCLCPP_ERROR_STREAM(
       node_->get_logger(),
-      "/" << controller_name <<
+      controller_name <<
         "/follow_joint_trajectory action server not available after waiting");
     return {};
   }
@@ -670,7 +673,7 @@ FollowJTGoalHandleFutureResult MotionPlanner::send_trajectory(
     if (node_->now() - start_t > kTimeout) {
       RCLCPP_ERROR_STREAM(
         node_->get_logger(),
-        "Timeout while waiting for " << "/" << controller_name <<
+        "Timeout while waiting for " << controller_name <<
           "/follow_joint_trajectory result");
       return {};
     }


### PR DESCRIPTION
**Summary:**

- Use MoveGroupInterface::Options with move_group_namespace so the action client binds to /<ns>/move_action.
- Converted all absolute topic names to relative, so nodes respect their ROS namespace.
- Enable USE_SCOPED_HEADER_INSTALL_DIR to avoid header collisions in larger workspaces.

**Why:**
Ensures clean isolation in **multi-robot/multi-instance** setups, prevents cross-talk on global topics/actions, and makes headers future-proof.