### PR TITLE
add missing header

### DIFF
--- a/play_motion2/include/play_motion2/motion_loader.hpp
+++ b/play_motion2/include/play_motion2/motion_loader.hpp
@@ -16,6 +16,7 @@
 #define PLAY_MOTION2__MOTION_LOADER_HPP_
 
 #include <string>
+#include <functional>
 
 #include "play_motion2/types.hpp"
 #include "play_motion2_msgs/msg/motion.hpp"


### PR DESCRIPTION
ref. https://github.com/pal-robotics/play_motion2/pull/4

fix with GCC 15.2 on ros humble:
```cpp
Dans le fichier inclus depuis /…/src/play_motion2/play_motion2/src/utils/motion_loader.hpp:23,
                 depuis /…/src/play_motion2/play_motion2/src/utils/motion_loader.cpp:19:
/…/include/rclcpp/rclcpp/node_interfaces/node_parameters_interface.hpp:42:10: erreur: « function » dans l'espace de noms « std » ne nomme pas un type de patron
   42 |     std::function<
      |          ^~~~~~~~
/…/include/rclcpp/rclcpp/node_interfaces/node_parameters_interface.hpp:30:1: note: « std::function » est défini dans l'en-tête « <functional> » ; cela peut probablement être corrigé en ajoutant « #include <functional> »
   29 | #include "rclcpp/parameter.hpp"
  +++ |+#include <functional>
   30 | #include "rclcpp/visibility_control.hpp"
/…/include/rclcpp/rclcpp/node_interfaces/node_parameters_interface.hpp:46:3: erreur: « OnParametersSetCallbackType » ne nomme pas un type
   46 |   OnParametersSetCallbackType callback;
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/…/include/rclcpp/rclcpp/node_interfaces/node_parameters_interface.hpp:189:70: erreur: « OnParametersSetCallbackType » dans « struct rclcpp::node_interfaces::OnSetParametersCallbackHandle » ne nomme pas un type
  189 |   using OnParametersSetCallbackType = OnSetParametersCallbackHandle::OnParametersSetCallbackType;
      |                                                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~
/…/include/rclcpp/rclcpp/node_interfaces/node_parameters_interface.hpp:198:34: erreur: « OnParametersSetCallbackType » n'a pas été déclaré
  198 |   add_on_set_parameters_callback(OnParametersSetCallbackType callback) = 0;
      |                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~
```